### PR TITLE
add Ocean Protocol network urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ chainId*    | The hex representation of the chainId             | `string`      
 project*    | The name of the project that started this network | `string`                  | `POA.network`
 type*       | The type of the network                           | `enum(testnet,mainnet)`   | `testnet`
 url*        | A sample RPC endpoint                             | `string`                  | `https://sokol.poa.network`
+explorer*   | URL to network explorer                           | `string`                  | `https://submarine.oceanprotocol.com`
 
 \* = optional
 

--- a/atlas.json
+++ b/atlas.json
@@ -229,13 +229,16 @@
     "project": "Ocean Protocol",
     "type": "testnet",
     "networkId": "0x897",
-    "url": "https://duero.dev-ocean.com"
+    "url": "https://duero.dev-ocean.com",
+    "explorer": "https://submarine.duero.dev-ocean.com"
   },
   {
     "name": "Nile",
     "project": "Ocean Protocol",
     "type": "testnet",
-    "networkId": "0x2323"
+    "networkId": "0x2323",
+    "url": "https://nile.dev-ocean.com",
+    "explorer": "https://submarine.nile.dev-ocean.com"
   },
   {
     "name": "Spree",
@@ -279,7 +282,9 @@
     "name": "Pacific",
     "project": "Ocean Protocol",
     "type": "mainnet",
-    "networkId": "0xCEA11"
+    "networkId": "0xCEA11",
+    "url": "https://pacific.oceanprotocol.com",
+    "explorer": "https://submarine.oceanprotocol.com"
   },
   {
     "name": "Ether-1",


### PR DESCRIPTION
Add RPC URLs for all Ocean Protocol networks. Additionally, add new key `explorer` to hold URLs to respective network explorers.